### PR TITLE
다크모드 구현 및 설정 및 개인정보

### DIFF
--- a/src/components/common/BottomTabNav.jsx
+++ b/src/components/common/BottomTabNav.jsx
@@ -1,6 +1,8 @@
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
+import { subscribeToChats } from '../../firebase/chat';
 import HomeIconSvg from '../../assets/icons/icon-home.svg?react';
 import ChatIconSvg from '../../assets/icons/icon-message-circle-bold.svg?react';
 import PostIconSvg from '../../assets/icons/icon-edit.svg?react';
@@ -30,10 +32,12 @@ const NavItem = styled.button`
   gap: 4px;
   flex: 1;
   height: 100%;
-  color: ${({ $active, theme }) => $active ? theme.colors.primary : theme.colors.gray300};
+  color: ${({ $active, theme }) => ($active ? theme.colors.primary : theme.colors.gray300)};
 
-  svg path, svg circle, svg rect {
-    stroke: ${({ $active, theme }) => $active ? theme.colors.primary : theme.colors.gray300};
+  svg path,
+  svg circle,
+  svg rect {
+    stroke: ${({ $active, theme }) => ($active ? theme.colors.primary : theme.colors.gray300)};
   }
 `;
 
@@ -42,24 +46,29 @@ const NavLabel = styled.span`
   font-weight: ${({ theme }) => theme.fonts.weight.medium};
 `;
 
-const PostButton = styled.button`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 4px;
-  flex: 1;
-  height: 100%;
-  color: ${({ $active, theme }) => $active ? theme.colors.primary : theme.colors.gray300};
+const IconWrapper = styled.div`
+  position: relative;
+  display: inline-flex;
+`;
 
-  svg path {
-    fill: ${({ $active, theme }) => $active ? theme.colors.primary : theme.colors.gray300};
-    stroke: none;
-  }
+const UnreadDot = styled.div`
+  position: absolute;
+  top: 0;
+  right: -2px;
+  width: 10px;
+  height: 10px;
+  background-color: ${({ theme }) => theme.colors.primary};
+  border-radius: 50%;
+  border: 1.5px solid ${({ theme }) => theme.colors.white};
 `;
 
 const HomeIcon = () => <HomeIconSvg width="24" height="24" />;
-const ChatIcon = () => <ChatIconSvg width="24" height="24" />;
+const ChatIcon = ({ hasUnread }) => (
+  <IconWrapper>
+    <ChatIconSvg width="24" height="24" />
+    {hasUnread && <UnreadDot />}
+  </IconWrapper>
+);
 const PostIcon = () => <PostIconSvg width="24" height="24" />;
 const ProfileIcon = () => <ProfileIconSvg width="24" height="24" />;
 
@@ -67,13 +76,21 @@ const BottomTabNav = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { user } = useAuth();
+  const [hasUnread, setHasUnread] = useState(false);
 
-  const tabs = [
-    { label: '홈', path: '/feed', icon: HomeIcon },
-    { label: '채팅', path: '/chat', icon: ChatIcon },
-    { label: '게시글', path: '/post/create', icon: PostIcon, isPost: true },
-    { label: '프로필', path: `/profile/${user?.accountname}`, icon: ProfileIcon },
-  ];
+  useEffect(() => {
+    if (!user?.accountname) return;
+    const unsubscribe = subscribeToChats(user.accountname, (chats) => {
+      const unread = chats.some((chat) => {
+        if (!chat.lastMessage || chat.lastSenderId === user.accountname) return false;
+        const myReadAt = chat.readAt?.[user.accountname];
+        if (!myReadAt) return true;
+        return (chat.lastMessageAt?.toMillis() || 0) > myReadAt.toMillis();
+      });
+      setHasUnread(unread);
+    });
+    return () => unsubscribe();
+  }, [user?.accountname]);
 
   const isActive = (path) => {
     if (path === '/feed') return location.pathname === '/feed' || location.pathname === '/';
@@ -83,16 +100,25 @@ const BottomTabNav = () => {
 
   return (
     <NavWrapper>
-      {tabs.map((tab) => {
-        const active = isActive(tab.path);
-        const Icon = tab.icon;
-        return (
-          <NavItem key={tab.label} $active={active} onClick={() => navigate(tab.path)}>
-            <Icon active={active} />
-            <NavLabel>{tab.label}</NavLabel>
-          </NavItem>
-        );
-      })}
+      <NavItem $active={isActive('/feed')} onClick={() => navigate('/feed')}>
+        <HomeIcon />
+        <NavLabel>홈</NavLabel>
+      </NavItem>
+      <NavItem $active={isActive('/chat')} onClick={() => navigate('/chat')}>
+        <ChatIcon hasUnread={hasUnread} />
+        <NavLabel>채팅</NavLabel>
+      </NavItem>
+      <NavItem $active={isActive('/post/create')} onClick={() => navigate('/post/create')}>
+        <PostIcon />
+        <NavLabel>게시글</NavLabel>
+      </NavItem>
+      <NavItem
+        $active={isActive(`/profile/${user?.accountname}`)}
+        onClick={() => navigate(`/profile/${user?.accountname}`)}
+      >
+        <ProfileIcon />
+        <NavLabel>프로필</NavLabel>
+      </NavItem>
     </NavWrapper>
   );
 };


### PR DESCRIPTION
  - 전역 다크모드 도입                                             
  - 라이트/다크 테마 토큰 분리 (src/styles/theme.js)               
  - 테마 모드 컨텍스트 추가 + localStorage 저장 (src/context/      
    ThemeModeContext.jsx)                                          
  - 앱 전체 ThemeProvider를 모드 기반으로 연결 (src/main.jsx)      
  - 설정/개인정보 UI 흐름 변경 (src/pages/Profile/Profile.jsx)     
  - ... 메뉴 → 설정 및 개인정보 진입                               
  - 하단시트가 아닌 전체화면 설정창으로 변경                       
  - 상단 타이틀 + X 정렬, 하단 닫기 버튼 제거                      
  - 다크모드 ON/OFF 토글 추가                                      
  - 개인정보 섹션 추가 (Profile.jsx)                               
  - 개인정보 클릭 시 펼침                                          
  - 표시 항목: email, username, accountname (비밀번호 제거)        
  - 이메일 표시 안정화                                             
  - 로그인 시 email 강제 보존 (src/pages/Login/LoginEmail.jsx)     
  - AuthContext에서 email 복원/저장 로직 추가 (src/context/        
    AuthContext.jsx)                                               
  - 개인정보 펼칠 때 getMyInfo() 재조회로 최신 email 반영          
    (Profile.jsx)                                                  
  - 다크모드 헤더 화살표 색상 반영                                 
  - 백아이콘 stroke를 테마색으로 강제 (src/components/common/      
    Header.jsx, src/assets/icons/icon-arrow-left.svg)   