### PR TITLE
refactor: BASE_URL / IMAGE_BASE_URL 공통 상수 파일로 통합

### DIFF
--- a/src/api/config.js
+++ b/src/api/config.js
@@ -1,6 +1,5 @@
 import axios from 'axios';
-
-const BASE_URL = 'https://dev.wenivops.co.kr/services/mandarin';
+import { BASE_URL, IMAGE_BASE_URL } from '../constants/url';
 
 const axiosInstance = axios.create({
   baseURL: BASE_URL,
@@ -36,5 +35,5 @@ axiosInstance.interceptors.response.use(
   }
 );
 
-export const IMAGE_BASE_URL = BASE_URL;
 export default axiosInstance;
+export { IMAGE_BASE_URL };

--- a/src/constants/url.js
+++ b/src/constants/url.js
@@ -1,0 +1,2 @@
+export const BASE_URL = 'https://dev.wenivops.co.kr/services/mandarin';
+export const IMAGE_BASE_URL = BASE_URL;

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -1,10 +1,12 @@
-// 가격 포맷 (숫자 → 원단위)
+import { IMAGE_BASE_URL } from '../constants/url';
+
+// 가격 포맷 (숫자 -> 원단위)
 export const formatPrice = (price) => {
   if (!price && price !== 0) return '';
   return Number(price).toLocaleString('ko-KR');
 };
 
-// 가격 입력 정수화 (문자 → 숫자)
+// 가격 입력 정수화 (문자 -> 숫자)
 export const parsePrice = (value) => {
   return value.replace(/[^0-9]/g, '');
 };
@@ -32,9 +34,7 @@ export const formatDate = (dateString) => {
   return `${year}년 ${month}월 ${day}일`;
 };
 
-const IMAGE_BASE_URL = 'https://dev.wenivops.co.kr/services/mandarin';
-
-// 이미지 URL 처리 (상대경로 → 절대경로)
+// 이미지 URL 처리 (상대경로 -> 절대경로)
 export const getImageUrl = (url) => {
   if (!url) return '';
   if (url.startsWith('http')) return url;


### PR DESCRIPTION
1. 공통 상수 파일 생성                                
     src/constants/url.js                               
                                                        
  export const BASE_URL =                               
  'https://dev.wenivops.co.kr/services/mandarin';       
  export const IMAGE_BASE_URL = BASE_URL;               
                                                        
  2. config.js에서 로컬 상수 제거 후 공통 상수 import   
     src/api/config.js                                  
  3. format.js에서 로컬 IMAGE_BASE_URL 제거 후 공통 상수     import                                             
     src/utils/format.js                   