### PR TITLE
fix(chatroom): 채팅방 진입 시 스크롤 및 테마 색상 깜빡임 수정

### DIFF
--- a/src/pages/Chat/ChatRoom.jsx
+++ b/src/pages/Chat/ChatRoom.jsx
@@ -298,8 +298,10 @@ const ChatRoom = () => {
   const [bubbleColor, setBubbleColor] = useState(BUBBLE_COLORS[0].value);
   const [otherBubbleColor, setOtherBubbleColor] = useState(null);
   const [bgImage, setBgImage] = useState(null);
+  const [themeReady, setThemeReady] = useState(false);
   const [isBgImageUploading, setIsBgImageUploading] = useState(false);
   const themeInitialized = useRef(false);
+  const isInitialLoad = useRef(true);
   const [likedMessages, setLikedMessages] = useState(new Set());
 
   useEffect(() => {
@@ -317,6 +319,7 @@ const ChatRoom = () => {
     if (saved?.otherBubbleColor) setOtherBubbleColor(saved.otherBubbleColor);
     if (saved?.bgImage) setBgImage(saved.bgImage);
     themeInitialized.current = true;
+    setThemeReady(true);
   }, [chatInfo, user?.accountname]);
 
   useEffect(() => {
@@ -330,8 +333,14 @@ const ChatRoom = () => {
     }
   }, [chatId, user?.accountname]);
 
-  useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  useLayoutEffect(() => {
+    if (messages.length === 0) return;
+    if (isInitialLoad.current) {
+      bottomRef.current?.scrollIntoView({ behavior: 'instant' });
+      isInitialLoad.current = false;
+    } else {
+      bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }
   }, [messages]);
 
   useEffect(() => {
@@ -536,7 +545,7 @@ const ChatRoom = () => {
           alwaysVisible
         />
 
-        <MessageList>
+        <MessageList style={{ visibility: themeReady ? 'visible' : 'hidden' }}>
           {messages.map((msg, index) => {
             const isMine = msg.senderId === user?.accountname;
             const currentDateKey = getMsgDateKey(msg.createdAt);


### PR DESCRIPTION
- useLayoutEffect로 초기 스크롤을 페인트 전에 처리해 위→아래 스크롤 현상 제거
- 초기 진입 시 instant 스크롤, 이후 새 메시지는 smooth 스크롤 적용
- themeReady 상태 추가로 Firebase 테마 로드 전까지 메시지 영역 숨김 처리