### PR TITLE
fix(image): data: URL 프리뷰 깨짐 버그 수정

### DIFF
--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -37,7 +37,7 @@ export const formatDate = (dateString) => {
 // 이미지 URL 처리 (상대경로 -> 절대경로)
 export const getImageUrl = (url) => {
   if (!url) return '';
-  if (url.startsWith('http')) return url;
+  if (url.startsWith('http') || url.startsWith('data:')) return url;
   return `${IMAGE_BASE_URL}/${url}`;
 };
 


### PR DESCRIPTION
getImageUrl에서 data: URL을 http와 동일하게 그대로 반환하도록 처리.
FileReader로 생성된 data: URL이 IMAGE_BASE_URL 접두사로 오염되어 프로필 이미지 미리보기가 깨지는 문제 수정.
- src/utils/format.js: getImageUrl data: URL 예외 처리 추가