### PR TITLE
design/피드 헤더 다크모드 아이콘 색상 통일

### DIFF
--- a/src/components/common/Header/styles.jsx
+++ b/src/components/common/Header/styles.jsx
@@ -23,8 +23,13 @@ export const HeartIcon = styled(HeartIconSvg)`
 
 export const MoreIcon = () => <MoreIconSvg width="24" height="24" />;
 
-export const SearchIcon = ({ size = 24 }) => <SearchIconSvg width={size} height={size} />;
-
+export const SearchIcon = styled(SearchIconSvg)`
+  width: 24px;
+  height: 24px;
+  path {
+    stroke: ${({ theme }) => theme.colors.gray400};
+  }
+`;
 export const HeaderWrapper = styled.header`
   position: fixed;
   top: 0;


### PR DESCRIPTION
- 다크모드에서 피드 헤더 하트 아이콘과 돋보기 아이콘의 색상 불일치 수정
- SearchIcon에 테마 색상(gray400) 적용